### PR TITLE
add support for appending random bytes to a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/rakyll/hey.svg?branch=master)](https://travis-ci.org/rakyll/hey)
 
+### This is a fork of `hey` that allows us to append random bytes to a URL
+
 hey is a tiny program that sends some load to a web application.
 
 hey was originally called boom and was influenced from Tarek Ziade's
@@ -45,7 +47,8 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
-
+  -r  Append random bytes to a URL
+  
   -host	HTTP Host header.
 
   -disable-compression  Disable compression.
@@ -54,6 +57,8 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
+  -rcount               Number of bytes to append to each request;
+						used together with -r; default: 10
 ```
 
 Previously known as [github.com/rakyll/boom](https://github.com/rakyll/boom).

--- a/hey.go
+++ b/hey.go
@@ -55,9 +55,11 @@ var (
 	q = flag.Float64("q", 0, "")
 	t = flag.Int("t", 20, "")
 	z = flag.Duration("z", 0, "")
+	r = flag.Bool("r", false, "")
 
-	h2   = flag.Bool("h2", false, "")
-	cpus = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
+	h2     = flag.Bool("h2", false, "")
+	cpus   = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
+	rcount = flag.Int("rcount", 10, "")
 
 	disableCompression = flag.Bool("disable-compression", false, "")
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
@@ -90,6 +92,8 @@ Options:
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
   -h2 Enable HTTP/2.
+  -r  Append random bytes to a URL
+  
 
   -host	HTTP Host header.
 
@@ -98,7 +102,9 @@ Options:
                         connections between different HTTP requests.
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
-                        (default for current machine is %d cores)
+						(default for current machine is %d cores)
+  -rcount               Number of bytes to append to each request;
+						used together with -r; default: 10
 `
 
 func main() {
@@ -217,6 +223,8 @@ func main() {
 		RequestBody:        bodyAll,
 		N:                  num,
 		C:                  conc,
+		R:                  *r,
+		RCount:             *rcount,
 		QPS:                q,
 		Timeout:            *t,
 		DisableCompression: *disableCompression,

--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -73,10 +73,9 @@ func TestQps(t *testing.T) {
 }
 
 func TestRequest(t *testing.T) {
-	var uri, contentType, some, method, auth string
+	var uri, contentType, some, auth string
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		uri = r.RequestURI
-		method = r.Method
 		contentType = r.Header.Get("Content-type")
 		some = r.Header.Get("X-some")
 		auth = r.Header.Get("Authorization")


### PR DESCRIPTION
* Add `-r` and `-rcount` for enabling random byte functionality and the number of bytes that should be generated and appended.

Using @relistan's random byte func.